### PR TITLE
removed "skip" parts from the firmware functions

### DIFF
--- a/src/raw/firmware.rs
+++ b/src/raw/firmware.rs
@@ -38,7 +38,7 @@ pub enum Port {
 /// select a port (default 0).
 pub async unsafe fn send_port(serial: &mut impl DerefMut<Target = Uart>, port: Port) -> Result<()> {
     let s = format!("port {}\r", port as u8);
-    let _ = write_and_skip(serial, s.as_bytes()).await?;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Represents the orange and green led's mode on the build hat.
@@ -57,7 +57,7 @@ pub async unsafe fn send_ledmode(
     mode: LedMode,
 ) -> Result<()> {
     let s = format!("ledmode {}\r", mode as i8);
-    let _ = write_and_skip(serial, s.as_bytes()).await?;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 // todo: implement pid
@@ -68,7 +68,7 @@ pub async unsafe fn send_set_point(
     setpoint: f32,
 ) -> Result<(), SerialError> {
     let s = format!("set {}\r", setpoint);
-    let _ = write_and_skip(serial, s.as_bytes()).await?;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Parameters for [`send_set_waveparams`].
@@ -142,7 +142,7 @@ pub async unsafe fn send_set_waveparams(
     params: WaveParams,
 ) -> Result<()> {
     let s = format!("set {}\r", params.to_string());
-    write_and_skip(serial, s.as_bytes()).await?;
+    write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Represents parameters for PWM driver. Refer to [`send_pwmparams`]
@@ -162,7 +162,7 @@ pub async unsafe fn send_pwmparams(
     pwmparams: PwmParams,
 ) -> Result<()> {
     let s = format!("pwmparams {}\r", pwmparams.to_string());
-    write_and_skip(serial, s.as_bytes()).await?;
+    write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// set PWM output drive limit for all ports (default 0.1).
@@ -170,14 +170,14 @@ pub async unsafe fn send_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
 ) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("plimit {limit}\r").as_bytes()).await
+    write(serial, format!("plimit {limit}\r").as_bytes()).await
 }
 /// set PWM output drive limit for current port.
 pub async unsafe fn send_port_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
 ) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("port_plimit {limit}\r").as_bytes()).await
+    write(serial, format!("port_plimit {limit}\r").as_bytes()).await
 }
 
 // todo: send_select_var
@@ -186,7 +186,7 @@ pub async unsafe fn select_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
 ) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("select {mode}\r").as_bytes()).await
+    write(serial, format!("select {mode}\r").as_bytes()).await
 }
 // todo: select
 /// as [`select_mode'] but only report one data packet.
@@ -194,7 +194,7 @@ pub async unsafe fn selonce_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
 ) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("selonce {mode}\r").as_bytes()).await
+    write(serial, format!("selonce {mode}\r").as_bytes()).await
 }
 // todo: selrate
 // todo: combi
@@ -206,6 +206,6 @@ pub async unsafe fn send_echo(
     serial: &mut impl DerefMut<Target = Uart>,
     enable_echo: bool,
 ) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("echo {}", enable_echo as u8).as_bytes()).await
+    write(serial, format!("echo {}", enable_echo as u8).as_bytes()).await
 }
 // todo: debug


### PR DESCRIPTION
before this change, ```write_and_skip()``` were used. They are now changed to ```write()```. This is because the skip part can block the program (since it had nothing to skip). This would result in the program to get stuck and not able to continue. 