### PR TITLE
Motor wrap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ lazy_static! {
 pub mod buildhat;
 pub mod parser;
 pub mod raw;
+pub mod motorWrap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,4 +25,4 @@ lazy_static! {
 pub mod buildhat;
 pub mod parser;
 pub mod raw;
-pub mod motorWrap;
+pub mod motor_wrap;

--- a/src/motorWrap.rs
+++ b/src/motorWrap.rs
@@ -1,0 +1,29 @@
+use std::clone;
+
+use crate::{raw::*, UART_SERIAL};
+use rppal::uart::Uart;
+use crate::raw::firmware::{send_port, send_plimit, send_pwm};
+
+use self::firmware::{send_set_point, Port};
+pub struct Motor{
+pub speed: u8,
+pub port: Port,
+pub limit: f32,
+}
+impl Motor{
+pub async fn new(motor_port: Port, limit: f32) -> Self {
+    let mut serial = UART_SERIAL.lock().await;
+    send_plimit(&mut serial, limit).await;
+    Self { speed: 0, port: motor_port, limit: limit }
+}
+pub async fn run(&self, speed: i8){
+    if (speed > 100 || speed < -100){
+        
+    }
+    let mut serial = UART_SERIAL.lock().await;
+    let _ = send_port(&mut serial, self.port.clone()).await;
+    let _ = send_pwm(&mut serial).await;
+    let _ = send_set_point(&mut serial, speed as f32 / 100.0).await;
+}
+
+}

--- a/src/motor_wrap.rs
+++ b/src/motor_wrap.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use std::clone;
 
 use crate::{raw::*, UART_SERIAL};
@@ -18,7 +19,7 @@ pub async fn new(motor_port: Port, limit: f32) -> Self {
 }
 pub async fn run(&self, speed: i8){
     if (speed > 100 || speed < -100){
-        
+        panic!("speed is over the limit!");
     }
     let mut serial = UART_SERIAL.lock().await;
     let _ = send_port(&mut serial, self.port.clone()).await;

--- a/src/motor_wrap.rs
+++ b/src/motor_wrap.rs
@@ -12,19 +12,30 @@ pub port: Port,
 pub limit: f32,
 }
 impl Motor{
-pub async fn new(motor_port: Port, limit: f32) -> Self {
-    let mut serial = UART_SERIAL.lock().await;
-    send_plimit(&mut serial, limit).await;
-    Self { speed: 0, port: motor_port, limit: limit }
-}
-pub async fn run(&self, speed: i8){
-    if (speed > 100 || speed < -100){
-        panic!("speed is over the limit!");
+
+    /// creates a new motor object.
+    /// 
+    /// # Parameters
+    /// * motor_port: Port to which the motor is connected.
+    /// * limit: Limit to how fast the motor can go. Usually 1.0 (100%)
+    pub async fn new(motor_port: Port, limit: f32) -> Self {
+        let mut serial = UART_SERIAL.lock().await;
+        send_plimit(&mut serial, limit).await;
+        Self { speed: 0, port: motor_port, limit: limit }
     }
-    let mut serial = UART_SERIAL.lock().await;
-    let _ = send_port(&mut serial, self.port.clone()).await;
-    let _ = send_pwm(&mut serial).await;
-    let _ = send_set_point(&mut serial, speed as f32 / 100.0).await;
-}
+
+    /// Rotates the motor at a given power
+    /// 
+    /// # Parameters
+    /// * speed: the power (-100 to 100)
+    pub async fn run(&self, speed: i8){
+        if (speed > 100 || speed < -100){
+            panic!("speed is over the limit!");
+        }
+        let mut serial = UART_SERIAL.lock().await;
+        let _ = send_port(&mut serial, self.port.clone()).await;
+        let _ = send_pwm(&mut serial).await;
+        let _ = send_set_point(&mut serial, speed as f32 / 100.0).await;
+    }
 
 }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -172,8 +172,8 @@ macro_rules! create_send_commands {
         $(
             paste::item! {
                 $(#[$meta])*
-                pub async fn [< send_ $name >] (serial: &mut impl DerefMut<Target=Uart>) -> Result<(), SerialError> {
-                    write(serial, $command.as_bytes()).await.map(|_| ());
+                pub async fn [< send_ $name >] (serial: &mut impl DerefMut<Target=Uart>) -> Result<()> {
+                    write(serial, $command.as_bytes()).await.map(|_| ())?;
                     Ok(())
                 }
             }

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -26,7 +26,7 @@ pub enum SerialError {
     GpioInitFailed,
 }
 /// Reset the build hat.
-pub async unsafe fn reset_hat(
+pub async fn reset_hat(
     serial: &mut impl DerefMut<Target = Uart>,
 ) -> Result<(), SerialError> {
     let gpio = Gpio::new().map_err(|_| SerialError::GpioInitFailed)?;
@@ -51,7 +51,7 @@ pub async unsafe fn reset_hat(
 /// Write data to the build hat.
 ///
 /// Consider using [`write_and_skip`] instead.
-pub async unsafe fn write(
+pub async fn write(
     serial: &mut impl DerefMut<Target = Uart>,
     data: &[u8],
 ) -> Result<usize, SerialError> {
@@ -61,7 +61,7 @@ pub async unsafe fn write(
 ///
 /// Rppal's Uart echoes the data you write. This function skips that data so that it doesn't get clogged up
 /// in other read functions.
-pub async unsafe fn write_and_skip(
+pub async fn write_and_skip(
     serial: &mut impl DerefMut<Target = Uart>,
     data: &[u8],
 ) -> Result<(), SerialError> {
@@ -70,7 +70,7 @@ pub async unsafe fn write_and_skip(
     Ok(())
 }
 /// Read a line as a string. This function will block forever until a line is read.
-pub async unsafe fn read_line(
+pub async fn read_line(
     serial: &mut impl DerefMut<Target = Uart>,
 ) -> Result<String, SerialError> {
     let mut complete_line = String::new();
@@ -96,13 +96,13 @@ pub async unsafe fn read_line(
     }
 }
 /// skip one line.
-pub async unsafe fn skip_line(
+pub async fn skip_line(
     serial: &mut impl DerefMut<Target = Uart>,
 ) -> Result<(), SerialError> {
     read_line(serial).await.map(|_| ())
 }
 /// Skip content such as the Uart echo after a write is performed.
-pub async unsafe fn skip_content(
+pub async fn skip_content(
     serial: &mut impl DerefMut<Target = Uart>,
     content: &[u8],
 ) -> Result<(), SerialError> {
@@ -139,13 +139,13 @@ pub async unsafe fn skip_content(
     Ok(())
 }
 /// Skip the text "BHBL> ". This piece of text appears on the bootloader terminal(?).
-pub async unsafe fn skip_prompt(serial: &mut impl DerefMut<Target = Uart>) -> Result<()> {
+pub async fn skip_prompt(serial: &mut impl DerefMut<Target = Uart>) -> Result<()> {
     skip_content(serial, "BHBL> ".as_bytes()).await?;
     // skip_content(serial, content).await?;
     Ok(())
 }
 /// Skip a `\r\n` line ending. (CRLF)
-pub async unsafe fn skip_line_ending(serial: &mut impl DerefMut<Target = Uart>) -> Result<()> {
+pub async fn skip_line_ending(serial: &mut impl DerefMut<Target = Uart>) -> Result<()> {
     skip_content(serial, "\r\n".as_bytes()).await?;
     Ok(())
 }
@@ -172,8 +172,9 @@ macro_rules! create_send_commands {
         $(
             paste::item! {
                 $(#[$meta])*
-                pub async unsafe fn [< send_ $name >] (serial: &mut impl DerefMut<Target=Uart>) -> Result<(), SerialError> {
-                    write_and_skip(serial, $command.as_bytes()).await.map(|_| ())
+                pub async fn [< send_ $name >] (serial: &mut impl DerefMut<Target=Uart>) -> Result<(), SerialError> {
+                    write(serial, $command.as_bytes()).await.map(|_| ());
+                    Ok(())
                 }
             }
         )*

--- a/src/raw/firmware.rs
+++ b/src/raw/firmware.rs
@@ -28,6 +28,7 @@ create_send_commands! {
 }
 
 /// Represents a port on the build hat.
+#[derive(Clone)]
 #[repr(u8)]
 pub enum Port {
     A = 0,
@@ -36,9 +37,9 @@ pub enum Port {
     D = 3,
 }
 /// select a port (default 0).
-pub async unsafe fn send_port(serial: &mut impl DerefMut<Target = Uart>, port: Port) -> Result<()> {
+pub async fn send_port(serial: &mut impl DerefMut<Target = Uart>, port: Port) -> Result<()> {
     let s = format!("port {}\r", port as u8);
-    let _ = write(serial, s.as_bytes()).await;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Represents the orange and green led's mode on the build hat.
@@ -52,23 +53,23 @@ pub enum LedMode {
     Both = 3,
 }
 /// set LED function
-pub async unsafe fn send_ledmode(
+pub async fn send_ledmode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: LedMode,
 ) -> Result<()> {
     let s = format!("ledmode {}\r", mode as i8);
-    let _ = write(serial, s.as_bytes()).await;
+    let _ = write_and_skip(serial, s.as_bytes()).await?;
     Ok(())
 }
 // todo: implement pid
 // todo: implement pid_diff
 /// configure constant set point for current port.
-pub async unsafe fn send_set_point(
+pub async fn send_set_point(
     serial: &mut impl DerefMut<Target = Uart>,
     setpoint: f32,
 ) -> Result<(), SerialError> {
     let s = format!("set {}\r", setpoint);
-    let _ = write(serial, s.as_bytes()).await;
+    let _ = write_and_skip(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Parameters for [`send_set_waveparams`].
@@ -137,12 +138,12 @@ impl ToString for WaveParams {
     }
 }
 /// configure varying set point for current port.
-pub async unsafe fn send_set_waveparams(
+pub async fn send_set_waveparams(
     serial: &mut impl DerefMut<Target = Uart>,
     params: WaveParams,
 ) -> Result<()> {
     let s = format!("set {}\r", params.to_string());
-    write(serial, s.as_bytes()).await;
+    write_and_skip(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Represents parameters for PWM driver. Refer to [`send_pwmparams`]
@@ -157,48 +158,44 @@ impl ToString for PwmParams {
 }
 
 /// configure parameters for PWM driver.
-pub async unsafe fn send_pwmparams(
+pub async fn send_pwmparams(
     serial: &mut impl DerefMut<Target = Uart>,
     pwmparams: PwmParams,
 ) -> Result<()> {
     let s = format!("pwmparams {}\r", pwmparams.to_string());
-    write(serial, s.as_bytes()).await;
+    write_and_skip(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// set PWM output drive limit for all ports (default 0.1).
-pub async unsafe fn send_plimit(
+pub async fn send_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
 ) -> Result<(), SerialError> {
-    write(serial, format!("plimit {limit}\r").as_bytes()).await;
-    Ok(())
+    write_and_skip(serial, format!("plimit {limit}\r").as_bytes()).await
 }
 /// set PWM output drive limit for current port.
-pub async unsafe fn send_port_plimit(
+pub async fn send_port_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
 ) -> Result<(), SerialError> {
-    write(serial, format!("port_plimit {limit}\r").as_bytes()).await;
-    Ok(())
+    write_and_skip(serial, format!("port_plimit {limit}\r").as_bytes()).await
 }
 
 // todo: send_select_var
 /// send a SELECT message to select a mode and output all its data in raw hex.
-pub async unsafe fn select_mode(
+pub async fn select_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
 ) -> Result<(), SerialError> {
-    write(serial, format!("select {mode}\r").as_bytes()).await;
-    Ok(())
+    write_and_skip(serial, format!("select {mode}\r").as_bytes()).await
 }
 // todo: select
 /// as [`select_mode'] but only report one data packet.
-pub async unsafe fn selonce_mode(
+pub async fn selonce_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
 ) -> Result<(), SerialError> {
-    write(serial, format!("selonce {mode}\r").as_bytes()).await;
-    Ok(())
+    write_and_skip(serial, format!("selonce {mode}\r").as_bytes()).await
 }
 // todo: selrate
 // todo: combi
@@ -206,11 +203,10 @@ pub async unsafe fn selonce_mode(
 // todo: write1
 // todo: write2
 /// enable/disable echo and prompt on command port.
-pub async unsafe fn send_echo(
+pub async fn send_echo(
     serial: &mut impl DerefMut<Target = Uart>,
     enable_echo: bool,
 ) -> Result<(), SerialError> {
-    write(serial, format!("echo {}", enable_echo as u8).as_bytes()).await;
-    Ok(())
+    write_and_skip(serial, format!("echo {}", enable_echo as u8).as_bytes()).await
 }
 // todo: debug

--- a/src/raw/firmware.rs
+++ b/src/raw/firmware.rs
@@ -1,5 +1,7 @@
 use std::fmt::format;
 
+use anyhow::Ok;
+
 use super::*;
 
 create_send_commands! {
@@ -58,7 +60,7 @@ pub async fn send_ledmode(
     mode: LedMode,
 ) -> Result<()> {
     let s = format!("ledmode {}\r", mode as i8);
-    let _ = write_and_skip(serial, s.as_bytes()).await?;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 // todo: implement pid
@@ -67,9 +69,9 @@ pub async fn send_ledmode(
 pub async fn send_set_point(
     serial: &mut impl DerefMut<Target = Uart>,
     setpoint: f32,
-) -> Result<(), SerialError> {
+) -> Result<()> {
     let s = format!("set {}\r", setpoint);
-    let _ = write_and_skip(serial, s.as_bytes()).await?;
+    let _ = write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Parameters for [`send_set_waveparams`].
@@ -143,7 +145,7 @@ pub async fn send_set_waveparams(
     params: WaveParams,
 ) -> Result<()> {
     let s = format!("set {}\r", params.to_string());
-    write_and_skip(serial, s.as_bytes()).await?;
+    write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// Represents parameters for PWM driver. Refer to [`send_pwmparams`]
@@ -163,22 +165,24 @@ pub async fn send_pwmparams(
     pwmparams: PwmParams,
 ) -> Result<()> {
     let s = format!("pwmparams {}\r", pwmparams.to_string());
-    write_and_skip(serial, s.as_bytes()).await?;
+    write(serial, s.as_bytes()).await?;
     Ok(())
 }
 /// set PWM output drive limit for all ports (default 0.1).
 pub async fn send_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
-) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("plimit {limit}\r").as_bytes()).await
+) -> Result<()> {
+    write(serial, format!("plimit {limit}\r").as_bytes()).await;
+    Ok(())
 }
 /// set PWM output drive limit for current port.
 pub async fn send_port_plimit(
     serial: &mut impl DerefMut<Target = Uart>,
     limit: f32,
-) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("port_plimit {limit}\r").as_bytes()).await
+) -> Result<()> {
+    write(serial, format!("port_plimit {limit}\r").as_bytes()).await;
+    Ok(())
 }
 
 // todo: send_select_var
@@ -186,16 +190,18 @@ pub async fn send_port_plimit(
 pub async fn select_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
-) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("select {mode}\r").as_bytes()).await
+) -> Result<()> {
+    write(serial, format!("select {mode}\r").as_bytes()).await;
+    Ok(())
 }
 // todo: select
 /// as [`select_mode'] but only report one data packet.
 pub async fn selonce_mode(
     serial: &mut impl DerefMut<Target = Uart>,
     mode: u8,
-) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("selonce {mode}\r").as_bytes()).await
+) -> Result<()> {
+    write(serial, format!("selonce {mode}\r").as_bytes()).await;
+    Ok(())
 }
 // todo: selrate
 // todo: combi
@@ -206,7 +212,8 @@ pub async fn selonce_mode(
 pub async fn send_echo(
     serial: &mut impl DerefMut<Target = Uart>,
     enable_echo: bool,
-) -> Result<(), SerialError> {
-    write_and_skip(serial, format!("echo {}", enable_echo as u8).as_bytes()).await
+) -> Result<()> {
+    write(serial, format!("echo {}", enable_echo as u8).as_bytes()).await;
+    Ok(())
 }
 // todo: debug


### PR DESCRIPTION
wrote the motor object. Now, you can:
create a new motor object: ```let motor = Motor::new(raw::firmware::Port::A, 1.0).await;```
run the motors: ```m1.run(100).await;```